### PR TITLE
Fix permissions bug

### DIFF
--- a/app/controllers/ForumController.php
+++ b/app/controllers/ForumController.php
@@ -12,7 +12,7 @@ class ForumController extends ApplicationController
             'before' => [
                 'sanitize_id' => ['only' => ['show']],
                 'mod_only' => ['only' => ['stick', 'unstick', 'lock', 'unlock']],
-                'member_only' => ['only' => ['destroy', 'update', 'edit', 'add', 'mark_all_read', 'preview']],
+                'member_only' => ['only' => ['destroy', 'update', 'edit', 'add', 'markAllRead', 'preview']],
                 'post_member_only' => ['only' => ['create']]
             ]
         ];

--- a/app/controllers/HistoryController.php
+++ b/app/controllers/HistoryController.php
@@ -227,4 +227,9 @@ class HistoryController extends ApplicationController
 
         $this->respond_to_success("Changes made.", ['action' => "index"], ['api' => ['successful' => $successful, 'failed' => $failed, 'errors' => $error_texts]]);
     }
+
+    protected function filters()
+    {
+        return ['before' => ['member_only' => ['only' => ['undo']]]];
+    }
 }

--- a/app/controllers/PoolController.php
+++ b/app/controllers/PoolController.php
@@ -11,9 +11,9 @@ class PoolController extends ApplicationController
         return [
             'before' => [
                 'user_can_see_posts' => ['only' => ['zip']],
-                'member_only' => ['only' => ['destroy', 'update', 'add_post', 'remove_post', 'import', 'zip']],
+                'member_only' => ['only' => ['destroy', 'update', 'addPost', 'removePost', 'import', 'zip']],
                 'post_member_only' => ['only' => ['create']],
-                'contributor_only' => ['only' => ['copy', 'transfer_metadata']]
+                'contributor_only' => ['only' => ['copy', 'transferMetadata']]
             ]
         ];
     }

--- a/app/controllers/PostController.php
+++ b/app/controllers/PostController.php
@@ -1129,11 +1129,11 @@ class PostController extends ApplicationController
         return [
             'before' => [
                 'user_can_see_posts' => ['only' => ['show', 'browse']],
-                'member_only' => ['only' => ['create', 'destroy', 'delete', 'flag', 'revert_tags', 'activate', 'update_batch', 'vote']],
+                'member_only' => ['only' => ['create', 'destroy', 'delete', 'flag', 'revertTags', 'activate', 'updateBatch', 'vote']],
                 'post_member_only' => ['only' => ['update', 'upload', 'flag']],
                 'janitor_only' => ['only' => ['moderate', 'undelete']],
                 'admin_only' => ['only' => ['import']],
-                'mod_only' => ['only' => ['search_external_data']]
+                'mod_only' => ['only' => ['searchExternalData']]
             ],
             'after' => [
                 'save_tags_to_cookie' => ['only' => ['update', 'create']]

--- a/app/controllers/TagController.php
+++ b/app/controllers/TagController.php
@@ -5,7 +5,7 @@ class TagController extends ApplicationController
     {
         return [
             'before' => [
-                'mod_only' => ['only' => ['mass_edit', 'edit_preview']],
+                'mod_only' => ['only' => ['massEdit', 'editPreview']],
                 'member_only' => ['only' => ['update', 'edit']]
             ]
         ];


### PR DESCRIPTION
Function names had previously been changed to camelCase without updating the references in the filters resulting in no permissions check for functions with multi-word names.
Fixed filter names to match. Also added a missing filter for "undo".